### PR TITLE
fix: Http connections allowed in debug builds android

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:usesCleartextTraffic="true">
+
+    </application>
 </manifest>


### PR DESCRIPTION
Now, By default, Http connections are not allowed.
We can change this behaviour by allowing clearTextTraffic in the debug manifest file for android .
I have also created a issue for this change.
