### PR TITLE
Removed use of deprecated title property in BottomNavigationBarItem

### DIFF
--- a/lib/components/add_url_bottom_sheet.dart
+++ b/lib/components/add_url_bottom_sheet.dart
@@ -44,7 +44,6 @@ class _AddBottomSheetState extends State<AddBottomSheet> {
   @override
   Widget build(BuildContext context) {
     double wp = MediaQuery.of(context).size.width;
-    double hp = MediaQuery.of(context).size.height;
     double bottomPadding = MediaQuery.of(context).viewInsets.bottom;
     return Padding(
       padding: EdgeInsets.only(bottom: bottomPadding),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -313,20 +313,15 @@ class _MainScreenState extends State<MainScreen> {
               Provider.of<Mode>(context).isDarkMode ? kGreyDT : null,
           selectedItemColor: Theme.of(context).primaryColor,
           currentIndex: _currentIndex,
+          selectedLabelStyle: TextStyle(fontWeight: FontWeight.bold),
+          unselectedLabelStyle: TextStyle(fontWeight: FontWeight.bold),
           type: BottomNavigationBarType.fixed,
           items: [
             BottomNavigationBarItem(
               icon: Icon(Icons.home),
-              title:
-                  Text('Home', style: TextStyle(fontWeight: FontWeight.bold)),
+              label: 'Home',
             ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.rss_feed),
-              title: Text(
-                'Feeds',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-            )
+            BottomNavigationBarItem(icon: Icon(Icons.rss_feed), label: 'Feeds')
           ],
           onTap: (index) {
             setState(() => _currentIndex = index);


### PR DESCRIPTION
## Description

I have maintained the same styling of `title` property and migrated to the `label` in BottomNavigationBarItem.

Relate Issue #21 