### PR TITLE
fix: Jank of the AppBar while switching to dark mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,9 +41,6 @@ class MyApp extends StatelessWidget {
       ),
       darkTheme: ThemeData.dark().copyWith(
         scaffoldBackgroundColor: kBackgroundDT,
-        appBarTheme: AppBarTheme(
-          color: kPrimaryDT,
-        ),
         canvasColor: kBackgroundDT,
         textTheme: ThemeData.dark().textTheme.apply(
               fontFamily: 'SFUIDisplay',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,6 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'ruTorrent Mobile',
       theme: ThemeData.light().copyWith(
-        appBarTheme: AppBarTheme(),
         textTheme: ThemeData.light().textTheme.apply(
               fontFamily: 'SFUIDisplay',
             ),


### PR DESCRIPTION
The `appBarTheme` property under `ThemeData()` is not required, by default Flutter takes the appBar color to be the `primaryColor` of the app, and specifying the `appBarTheme` property forces the brightness configuration to reset (causing the white flash of the AppBar).

After fix:

<img src="https://user-images.githubusercontent.com/43280874/107355428-735df000-6af5-11eb-85f9-a750eb2bcfab.gif" width="350"/>

Fixes: #33 