### PR TITLE
fix: remove Browse Torrent File button in AddBottomSheet

### DIFF
--- a/lib/components/add_url_bottom_sheet.dart
+++ b/lib/components/add_url_bottom_sheet.dart
@@ -31,14 +31,15 @@ class _AddBottomSheetState extends State<AddBottomSheet> {
   File torrentFile;
 
   void pickTorrentFile() async {
-    FilePickerResult result = await FilePicker.platform.pickFiles(type: FileType.custom,allowedExtensions: ["torrent"]);
+    FilePickerResult result = await FilePicker.platform
+        .pickFiles(type: FileType.custom, allowedExtensions: ["torrent"]);
     if (result == null) {
       Fluttertoast.showToast(msg: 'No file selected');
-    } else if(result.files.first.extension == "torrent")   {
+    } else if (result.files.first.extension == "torrent") {
       torrentPath = result.files.first.path;
       print("path: $torrentPath");
       ApiRequests.addTorrentFile(widget.api, torrentPath);
-    } else{
+    } else {
       Fluttertoast.showToast(msg: 'Invalid file selected');
     }
   }
@@ -113,29 +114,6 @@ class _AddBottomSheetState extends State<AddBottomSheet> {
                 ),
                 onPressed: () {
                   widget.apiRequest(urlTextController.text);
-                  Navigator.pop(context);
-                },
-              ),
-            ),
-            Container(
-              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 36),
-              width: double.infinity,
-              child: RaisedButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(5.0),
-                  side: BorderSide(color: Theme.of(context).primaryColor),
-                ),
-                color: Theme.of(context).primaryColor,
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
-                  child: Text(
-                    'Browse Torrent File',
-                    style: TextStyle(color: Colors.white, fontSize: 18),
-                  ),
-                ),
-                onPressed: () {
-                  pickTorrentFile();
                   Navigator.pop(context);
                 },
               ),


### PR DESCRIPTION
This was requested in the issue: https://github.com/CCExtractor/rutorrent-flutter/issues/35