### PR TITLE
style: Improvement on UI of ConfigurationsScreen

### DIFF
--- a/lib/components/data_input.dart
+++ b/lib/components/data_input.dart
@@ -5,6 +5,7 @@ import 'package:rutorrentflutter/models/mode.dart';
 
 class DataInput extends StatelessWidget {
   final String hintText;
+  final Color hintTextColor;
   final TextEditingController textEditingController;
   final FocusNode focus;
   final IconButton suffixIconButton;
@@ -12,14 +13,16 @@ class DataInput extends StatelessWidget {
   final textInputAction;
   final Color borderColor;
 
-  DataInput(
-      {this.hintText,
-      this.textEditingController,
-      this.onFieldSubmittedCallback,
-      this.focus,
-      this.textInputAction,
-      this.suffixIconButton,
-      this.borderColor});
+  DataInput({
+    this.hintText,
+    this.hintTextColor,
+    this.textEditingController,
+    this.onFieldSubmittedCallback,
+    this.focus,
+    this.textInputAction,
+    this.suffixIconButton,
+    this.borderColor,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +45,7 @@ class DataInput extends StatelessWidget {
             border: InputBorder.none,
             contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             hintText: hintText,
-            hintStyle: TextStyle(color: borderColor),
+            hintStyle: TextStyle(color: hintTextColor ?? borderColor),
             suffixIcon: suffixIconButton,
           ),
         ),

--- a/lib/screens/configurations_screen.dart
+++ b/lib/screens/configurations_screen.dart
@@ -21,6 +21,7 @@ class _ConfigurationsScreenState extends State<ConfigurationsScreen> {
   final TextEditingController urlController = TextEditingController();
   final TextEditingController usernameController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final FocusNode usernameFocus = FocusNode();
   final FocusNode passwordFocus = FocusNode();
   final FocusNode urlFocus = FocusNode();
   bool isValidating = false;
@@ -113,127 +114,143 @@ class _ConfigurationsScreenState extends State<ConfigurationsScreen> {
             AlwaysStoppedAnimation<Color>(Theme.of(context).primaryColor),
       ),
       inAsyncCall: isValidating,
-      child: Scaffold(
-        body: SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              Container(
-                color: Theme.of(context).primaryColor,
-                height: 260,
-                width: double.infinity,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                      vertical: 16.0, horizontal: 8.0),
-                  child: Column(
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 24),
-                        child: Image(
-                          image: AssetImage('assets/logo/white_logo.png'),
-                          height: 50,
-                        ),
-                      ),
-                      SizedBox(
-                        height: 10,
-                      ),
-                      DataInput(
-                        borderColor: Colors.white,
-                        textEditingController: urlController,
-                        hintText: 'Location of ruTorrent',
-                        focus: urlFocus,
-                        suffixIconButton: IconButton(
-                          color: Colors.white,
-                          onPressed: () async {
-                            ClipboardData data =
-                                await Clipboard.getData('text/plain');
-                            if (data != null)
-                              urlController.text = data.text.toString();
-                            if (urlFocus.hasFocus) urlFocus.unfocus();
-                          },
-                          icon: Icon(Icons.content_paste),
-                        ),
-                      ),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Icon(
-                              Icons.info_outline,
-                              color: Colors.white,
+      child: GestureDetector(
+        onTap: () {
+          urlFocus.unfocus();
+          usernameFocus.unfocus();
+          passwordFocus.unfocus();
+        },
+        child: Scaffold(
+          body: SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                Container(
+                  color: Theme.of(context).primaryColor,
+                  width: double.infinity,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 16.0,
+                      horizontal: 8.0,
+                    ),
+                    child: Column(
+                      children: <Widget>[
+                        SafeArea(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              top: 8.0,
+                              bottom: 24.0,
+                            ),
+                            child: Image(
+                              image: AssetImage('assets/logo/white_logo.png'),
+                              height: 50,
                             ),
                           ),
-                          Flexible(
-                            child: Text(
-                              'Check your browser address bar',
-                              style: TextStyle(
+                        ),
+                        SizedBox(
+                          height: 10,
+                        ),
+                        DataInput(
+                          borderColor: Colors.white,
+                          textEditingController: urlController,
+                          hintText: 'Location of ruTorrent',
+                          hintTextColor: Colors.white54,
+                          focus: urlFocus,
+                          suffixIconButton: IconButton(
+                            color: Colors.white,
+                            onPressed: () async {
+                              ClipboardData data =
+                                  await Clipboard.getData('text/plain');
+                              if (data != null)
+                                urlController.text = data.text.toString();
+                              if (urlFocus.hasFocus) urlFocus.unfocus();
+                            },
+                            icon: Icon(Icons.content_paste),
+                          ),
+                        ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: <Widget>[
+                            Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Icon(
+                                Icons.info_outline,
+                                color: Colors.white,
+                              ),
+                            ),
+                            Flexible(
+                              child: Text(
+                                'Check your browser address bar',
+                                style: TextStyle(
                                   color: Colors.white,
                                   fontSize: 12,
-                                  fontWeight: FontWeight.w600),
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
                             ),
-                          ),
-                        ],
-                      )
-                    ],
+                          ],
+                        )
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              SizedBox(
-                height: 10,
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: DataInput(
-                  onFieldSubmittedCallback: (v) {
-                    FocusScope.of(context).requestFocus(passwordFocus);
-                  },
-                  textEditingController: usernameController,
-                  hintText: 'Username',
-                  textInputAction: TextInputAction.next,
+                SizedBox(
+                  height: 10,
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: PasswordInput(
-                  textEditingController: passwordController,
-                  passwordFocus: passwordFocus,
-                ),
-              ),
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(vertical: 16, horizontal: 32),
-                child: Container(
-                  width: double.infinity,
-                  child: RaisedButton(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(5.0),
-                      side: BorderSide(color: Theme.of(context).primaryColor),
-                    ),
-                    color: Provider.of<Mode>(context).isLightMode
-                        ? Colors.white
-                        : Colors.black,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 28, vertical: 16),
-                      child: Text(
-                        'Let\'s get started',
-                        style: TextStyle(
-                            color: Theme.of(context).primaryColor,
-                            fontSize: 18),
-                      ),
-                    ),
-                    onPressed: () {
-                      Api api = Provider.of<Api>(context,
-                          listen: false); // One call to provider
-                      api.setUrl(urlController.text);
-                      api.setUsername(usernameController.text);
-                      api.setPassword(passwordController.text);
-                      _validateConfigurationDetails(api);
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: DataInput(
+                    onFieldSubmittedCallback: (v) {
+                      FocusScope.of(context).requestFocus(passwordFocus);
                     },
+                    focus: usernameFocus,
+                    textEditingController: usernameController,
+                    hintText: 'Username',
+                    textInputAction: TextInputAction.next,
                   ),
                 ),
-              )
-            ],
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: PasswordInput(
+                    textEditingController: passwordController,
+                    passwordFocus: passwordFocus,
+                  ),
+                ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 16, horizontal: 32),
+                  child: Container(
+                    width: double.infinity,
+                    child: RaisedButton(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5.0),
+                        side: BorderSide(color: Theme.of(context).primaryColor),
+                      ),
+                      color: Provider.of<Mode>(context).isLightMode
+                          ? Colors.white
+                          : Colors.black,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 28, vertical: 16),
+                        child: Text(
+                          'Let\'s get started',
+                          style: TextStyle(
+                              color: Theme.of(context).primaryColor,
+                              fontSize: 18),
+                        ),
+                      ),
+                      onPressed: () {
+                        Api api = Provider.of<Api>(context,
+                            listen: false); // One call to provider
+                        api.setUrl(urlController.text);
+                        api.setUsername(usernameController.text);
+                        api.setPassword(passwordController.text);
+                        _validateConfigurationDetails(api);
+                      },
+                    ),
+                  ),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/configurations_screen.dart
+++ b/lib/screens/configurations_screen.dart
@@ -121,6 +121,7 @@ class _ConfigurationsScreenState extends State<ConfigurationsScreen> {
           passwordFocus.unfocus();
         },
         child: Scaffold(
+          backgroundColor: Colors.white,
           body: SingleChildScrollView(
             child: Column(
               children: <Widget>[


### PR DESCRIPTION
## Improvements
I have done a few improvements on the UI of **ConfigurationsScreen**:
* The **ruTorrent** logo was overlapping a bit with the status bar, and no padding was there. Add proper padding and `SafeArea` widget to prevent overlapping irrespective of the device it is run on.
* Dismiss the `TextField` focus as the user taps outside the field (and retracts the keyboard).
* Change the color of the hint text to be less highlighting (as per the material design guidelines).
* Add white background color to the `Scaffold` (the color that is set by default is not exactly pure white in Flutter).

## Before & After:

<img src="https://user-images.githubusercontent.com/43280874/107785490-aa8d0500-6d72-11eb-874c-e2412a85371b.png" width="400"/> <img src="https://user-images.githubusercontent.com/43280874/107786280-b3caa180-6d73-11eb-927b-d4143e439543.png" width="400"/>