### PR TITLE
fix: fixes text clipping for long torrent names

### DIFF
--- a/lib/components/torrent_tile.dart
+++ b/lib/components/torrent_tile.dart
@@ -74,11 +74,15 @@ class TorrentTile extends StatelessWidget {
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: <Widget>[
                               Flexible(
-                                  child: Text(
-                                torrent.name,
-                                style: TextStyle(
-                                    fontWeight: FontWeight.w600, fontSize: 16),
-                              )),
+                                child: Text(
+                                  torrent.name,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 16),
+                                ),
+                              ),
                               Flexible(
                                 child: Text(
                                   '${filesize(torrent.downloadedData)}${torrent.dlSpeed == 0 ? '' : ' | ' + torrent.getEta}',


### PR DESCRIPTION
fixes #54 

This is the new result 

<img src="https://user-images.githubusercontent.com/43833743/109423963-a9610680-7a07-11eb-945c-aaf2c89dd6a0.jpg" width=300 alt="Screenshot">
