### PR TITLE
fix: Added alternative to getExternalStorageDirectory for iOS

### DIFF
--- a/lib/pages/downloads_page.dart
+++ b/lib/pages/downloads_page.dart
@@ -22,7 +22,11 @@ class _DownloadsPageState extends State<DownloadsPage> {
   }
 
   _initFiles() async {
-    _homeDirectory = (await getExternalStorageDirectory()).path + '/';
+    if (Platform.isAndroid) {
+      _homeDirectory = (await getExternalStorageDirectory()).path + '/';
+    } else {
+      _homeDirectory = (await getApplicationDocumentsDirectory()).path + '/';
+    }
     _directory = _homeDirectory;
     _syncFiles();
   }


### PR DESCRIPTION
Fixed the issue that was caused due to incompatibility of ```getExternalStorageDirectory()``` for iOS and instead used ```getApplicationDocumentsDirectory()```

Fixes: #68 