### PR TITLE
Added dark mode support for Loading Screen

### DIFF
--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -53,7 +53,6 @@ class _LoadingScreenState extends State<LoadingScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
       body: Column(
         children: <Widget>[
           Expanded(
@@ -71,7 +70,9 @@ class _LoadingScreenState extends State<LoadingScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 32),
             child: Image(
               height: 40,
-              image: AssetImage('assets/logo/name_logo.png'),
+              image: AssetImage(Theme.of(context).brightness == Brightness.light
+                  ? 'assets/logo/name_logo.png'
+                  : 'assets/logo/dark_mode.png'),
             ),
           )
         ],


### PR DESCRIPTION
## Description

The loading_screen doesn't support dark mode because of the hardcoded white background color. I have removed it and added a check for the logo to switch according to the selected theme mode.

Screenshot: 
![photo_2021-03-12_00-14-07](https://user-images.githubusercontent.com/36601970/110838174-26259780-82c8-11eb-9af0-580aa2b8f8f7.jpg)
