### PR TITLE
docs: Removed redundant steps for ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ flutter doctor
 ```
 
 4. For IOS
-- Delete ios folder from the root directory ```/ios```
-- From the root directory```flutter create -i swift --project-name rutorrent . ```
 - Uncomment ```platform :ios, '9.0'``` from ios/Podfile
 - Cd into the new ios directory```cd ios```
-- From the ios directory ```pod install ```
+- From the ios directory ```pod install --verbose```
 
 5. Run the app:
 


### PR DESCRIPTION
The vlc package requires the swift version of the ios root (https://pub.dev/packages/flutter_vlc_player/versions/3.0.3) folder which wasn't merged in the master earlier. Since that is now done, I guess the first two steps are redundant and would need to be removed.

![Screenshot 2021-03-12 at 6 41 00 PM](https://user-images.githubusercontent.com/52864956/110944473-85d08100-8362-11eb-9de9-3a17a6449a36.png)
