### PR TITLE
fix: pull to refresh in rss feeds page & exact msg for adding rss

### DIFF
--- a/lib/components/add_url_bottom_sheet.dart
+++ b/lib/components/add_url_bottom_sheet.dart
@@ -131,7 +131,9 @@ class _AddBottomSheetState extends State<AddBottomSheet> {
                 padding:
                     const EdgeInsets.symmetric(horizontal: 28, vertical: 16),
                 child: Text(
-                  'Start Download',
+                  (widget.dialogHint == "Enter Rss Url")
+                      ? 'Add RSS Feed'
+                      : 'Start Download',
                   style: TextStyle(color: Colors.white, fontSize: 18),
                 ),
               ),

--- a/lib/pages/rss_feeds.dart
+++ b/lib/pages/rss_feeds.dart
@@ -63,13 +63,21 @@ class _RSSFeedsState extends State<RSSFeeds> {
                           ),
                         )
                       : Expanded(
-                          child: Center(
-                            child: SvgPicture.asset(
-                              Theme.of(context).brightness == Brightness.light
-                                  ? 'assets/logo/empty.svg'
-                                  : 'assets/logo/empty_dark.svg',
-                              width: 120,
-                              height: 120,
+                          child: SingleChildScrollView(
+                            physics: AlwaysScrollableScrollPhysics(),
+                            child: Container(
+                              height: MediaQuery.of(context).size.height / 1.75,
+                              alignment: Alignment.center,
+                              child: Center(
+                                child: SvgPicture.asset(
+                                  Theme.of(context).brightness ==
+                                          Brightness.light
+                                      ? 'assets/logo/empty.svg'
+                                      : 'assets/logo/empty_dark.svg',
+                                  width: 120,
+                                  height: 120,
+                                ),
+                              ),
                             ),
                           ),
                         ),


### PR DESCRIPTION
- Fixes pull to refresh feature in RSS feeds as the page takes longer to update on adding RSS. 
- Changes the button text on add RSS bottom sheet (from "Start download" to "Add RSS feed")