### PR TITLE
Better visibility to status bar in configurationsScreen page

### DIFF
--- a/lib/screens/configurations_screen.dart
+++ b/lib/screens/configurations_screen.dart
@@ -109,9 +109,16 @@ class _ConfigurationsScreenState extends State<ConfigurationsScreen> {
       }
     }
   }
-
+  _changeStatusBarColor(){
+    SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+      statusBarColor: Colors.white
+    ));
+  }
   @override
   Widget build(BuildContext context) {
+    //change status bar color to white for better visibility of status bar 
+    _changeStatusBarColor();
+    
     return ModalProgressHUD(
       progressIndicator: CircularProgressIndicator(
         valueColor:


### PR DESCRIPTION
## Problem  
status bar of configurationsScreen was not properly visible.

## Solution 
Implemented `setSystemUIOverlayStyle` flutter function to change status color, to make more it readable to end users.

## Code

>   _changeStatusBarColor(){
>         SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
>         statusBarColor: Colors.white
>       ));
>   }

## Results 
![Capture](https://user-images.githubusercontent.com/52353967/111351650-65c5f800-86a9-11eb-8e14-7efb43b9f920.PNG)
