### PR TITLE
Configurations Screen credentials check method updated

### DIFF
--- a/lib/screens/configurations_screen.dart
+++ b/lib/screens/configurations_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/screens/configurations_screen.dart
+++ b/lib/screens/configurations_screen.dart
@@ -90,18 +90,21 @@ class _ConfigurationsScreenState extends State<ConfigurationsScreen> {
     }
 
     var response;
-    int total;
     try {
-      response = await api.ioClient
-          .get(Uri.parse(api.diskSpacePluginUrl), headers: api.getAuthHeader());
-      total = jsonDecode(response.body)['total'];
+      response = await api.ioClient.post(
+        Uri.parse(api.httpRpcPluginUrl),
+        headers: api.getAuthHeader(),
+        body: {
+          'mode': 'list',
+        },
+      );
     } catch (e) {
       Fluttertoast.showToast(msg: 'Invalid');
     } finally {
       setState(() {
         isValidating = false;
       });
-      if (response != null && total != null) {
+      if (response != null) {
         response.statusCode == 200
             ? // SUCCESS
             saveLogin(api)

--- a/lib/screens/vlc_stream.dart
+++ b/lib/screens/vlc_stream.dart
@@ -31,9 +31,8 @@ class _VlcStreamState extends State<VlcStream> with WidgetsBindingObserver {
 
   _initVlcPlayer() async {
     _videoViewController = VlcPlayerController.network(widget.streamUrl,
-        hwAcc: HwAcc.FULL,
-        autoPlay: false,
-        options: VlcPlayerOptions(), onInit: () {
+        hwAcc: HwAcc.FULL, autoPlay: false, options: VlcPlayerOptions());
+    _videoViewController.addOnInitListener(() {
       _videoViewController.play();
     });
     _videoViewController.addListener(() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,13 +113,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
-  cryptoutils:
-    dependency: transitive
-    description:
-      name: cryptoutils
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -262,7 +255,14 @@ packages:
       name: flutter_vlc_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "6.0.2"
+  flutter_vlc_player_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_vlc_player_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
   flutter_web_plugins:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Description

Using `httpRpcPluginUrl` instead of `diskSpacePluginUrl` in configurations screen for validating the connection.

Fixes #131 

@harchani-ritik PTAL.